### PR TITLE
Windows machines don't support single quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check-types": "tsc",
     "eslint": "eslint ./src --ext .ts,.tsx",
     "lint": "npm run eslint && npm run check-types",
-    "start": "babel-node --extensions '.ts,.tsx' src/index.ts",
+    "start": "babel-node --extensions \".ts,.tsx\" src/index.ts",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
Without this change, windows machine will error out on npm start.
