### PR TITLE
Count ESLint warnings as errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src -d lib",
     "check-types": "tsc",
-    "eslint": "eslint ./src --ext .ts,.tsx",
+    "eslint": "eslint --max-warnings 0 ./src --ext .ts,.tsx",
     "lint": "npm run eslint && npm run check-types",
     "start": "babel-node --extensions \".ts,.tsx\" src/index.ts",
     "test": "jest"

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -10,6 +10,7 @@ const getHealth = async (): Promise<HealthStatus> => {
     await db.sql('health');
     return HealthStatus.AVAILABLE;
   } catch (err: unknown) {
+    // eslint-disable-next-line no-console -- TODO: set up proper logging
     console.log('Error connecting to database', err);
     return HealthStatus.UNAVAILABLE;
   }


### PR DESCRIPTION
Our CI system, GitHub Actions, looks at the return value of the commands it runs, and not its output. By default, the ruleset we've adopted considers some of its rules as warning-level rather than error-level; in ESLint, warnings do not cause a nonzero return value.

Update our invocation of ESLint to exit with an error status if there are any warning-level rule violations ([manual entry](https://eslint.org/docs/user-guide/command-line-interface#-max-warnings)). We could change just our CI, but I don't think it harms anything to change our script to error on warnings.

Also fix the sole warning we currently have, which I had missed previously - in part because the CI passed.