### PR TITLE
Tell git not to change source code line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sql text eol=lf
+*.ts text eol=lf


### PR DESCRIPTION
By default, git will automatically convert line endings on Windows, so that it stores the Unix-standard LF characters in the repository and the Windows-standard CRLF in the checked out copy.

Our tools do NOT like that.

We have ESLint set up with the Airbnb configuration, which requires Unix [linebreak-style](https://eslint.org/docs/rules/linebreak-style). Running it on Windows causes ESLint to report an error on literally every line of Typescript code, which is noisy and unhelpful.

More subtly, our [migrations library hashes the contents of the migration files, and stores the value in the database](https://github.com/ThomWright/postgres-migrations#hash-checks-for-previous-migrations). Changing whitespace in the migration files, including the line endings, causes the migration script to error at startup. While the current behavior is stable, in that repeatedly running with Windows line endings will work, the hashes stored in the database will differ from those stored in other developers' databases, and in dev/staging/production.

The solution to both problems is to tell git not to translate our source code on Windows. Modern Windows developer tools, including VS Code and the Jetbrains IDEs, know how to deal with Unix line breaks, so this workaround is not necessary. Configure our [`.gitattributes` file](https://git-scm.com/docs/gitattributes) to always use Unix line endings in our source code.

---

@mithuna , you will need to re-run all the migrations from scratch. To do so, run the SQL query `drop owned by current_user`, which should delete all the tables in the database; starting the service after that will recreate them via migration.