### PR TITLE
Add deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - run: npm install
+      - run: npm run build
+      - name: Create a tar archive
+        run: |
+          cd ..
+          tar --exclude=.git* --exclude=node_modules/* --exclude=src/* -czvf notification-service.tar.gz notification-service
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Copy package to S3
+        run: |
+          aws s3 cp ../notification-service.tar.gz s3://permanent-repos/dev/notification-service.tar.gz
+          aws s3 cp ../notification-service.tar.gz s3://permanent-repos/staging/notification-service.tar.gz
+          aws s3 cp ../notification-service.tar.gz s3://permanent-repos/prod/notification-service.tar.gz


### PR DESCRIPTION
Build the application on merging to main (and when run manually), and save the result to our S3 bucket to be deployed later.

Heavily based on the [version in upload-service](https://github.com/PermanentOrg/upload-service/blob/86394e7dc117c34d61e685efa784e2bb9b9eccf2/.github/workflows/deploy.yml); thanks to @xmunoz and @andrewatwood for their contributions to that!

Unfortunately, I believe the only way to test this is to merge and watch the action run. I am reassured that it is basically identical to the upload-service version, with some search-and-replace.

Issue #20 Need to build and package notification-service