### PR TITLE
Register device token

### DIFF
--- a/src/controllers/device.controller.ts
+++ b/src/controllers/device.controller.ts
@@ -1,0 +1,27 @@
+import type {
+  Handler,
+  Request,
+  Response,
+} from 'express';
+import { deviceService } from '../services';
+import { validateCreateDeviceParams } from '../validators';
+
+const addDevice: Handler = (
+  req: Request,
+  res: Response,
+): void => {
+  const validation = validateCreateDeviceParams(req.body);
+  if (validation.error) {
+    res.status(400).json({ error: validation.error });
+  } else {
+    deviceService.addDevice(req.body)
+      .then(() => res.json(req.body))
+      .catch((err: unknown) => res.status(500).json({
+        error: err,
+      }));
+  }
+};
+
+export const deviceController = {
+  addDevice,
+};

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,3 @@
+export { deviceController } from './device.controller';
 export { healthController } from './health.controller';
 export { notificationController } from './notification.controller';

--- a/src/database/migrations/3-create-device.sql
+++ b/src/database/migrations/3-create-device.sql
@@ -1,0 +1,6 @@
+CREATE TABLE devices (
+    user_id INTEGER NOT NULL,
+    device_token TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, device_token)
+)

--- a/src/database/queries/insert-devices.sql
+++ b/src/database/queries/insert-devices.sql
@@ -1,0 +1,4 @@
+INSERT
+INTO devices (user_id, device_token)
+VALUES (:user_id, :device_token)
+ON CONFLICT DO NOTHING

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
-import { healthController, notificationController } from '../controllers';
+import {
+  deviceController,
+  healthController,
+  notificationController,
+} from '../controllers';
 
 const apiRoutes = express.Router();
+apiRoutes.post('/devices', deviceController.addDevice);
 apiRoutes.get('/health', healthController.getHealth);
 apiRoutes.post('/notifications', notificationController.createNotification);
 

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -1,0 +1,17 @@
+import { db } from '../database';
+
+export interface Device {
+  userId: number;
+  deviceToken: string;
+}
+
+const addDevice = async (device: Device): Promise<void> => {
+  await db.sql('insert-devices', {
+    user_id: device.userId,
+    device_token: device.deviceToken,
+  });
+};
+
+export const deviceService = {
+  addDevice,
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
+export { deviceService } from './device.service';
 export { healthService } from './health.service';
 export { notificationService } from './notification.service';

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,1 +1,2 @@
+export { validateCreateDeviceParams } from './validateCreateDeviceParams';
 export { validateCreateNotificationParams } from './validateCreateNotificationParams';

--- a/src/validators/validateCreateDeviceParams.ts
+++ b/src/validators/validateCreateDeviceParams.ts
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+import type { Device } from '../services/device.service';
+
+export const validateCreateDeviceParams = (
+  data: Device,
+): Joi.ValidationResult => Joi.object().keys({
+  userId: Joi.number().integer().min(1).required(),
+  deviceToken: Joi.string().required(),
+}).validate(
+  data,
+  { abortEarly: false },
+);


### PR DESCRIPTION
## Description
- This PR will save users' device token in our database mapping user_id to
device tokens. Device tokens, as the name suggests, uniquely identify a
single device.

## Steps to Test
- This code will create a new device table and on post
localhost:3001/api/devices with values userId and deviceToken should
make an entry in device table.

## Issue 
#15 Register device tokens