### PR TITLE
Changing the return to be a JSON

### DIFF
--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -9,12 +9,16 @@ interface InsertNotificationResult{
   notification_id: number;
 }
 
-const createNotification = async (notification: Notification): Promise<number> => {
+const createNotification = async (notification: Notification): Promise<Object> => {
   const result = await db.sql<InsertNotificationResult>('insert-notification', {
     to_user_id: notification.toUserId,
     notification_type: notification.notificationType,
   });
-  return result.rows[0].notification_id;
+  var jsonResult = {
+    "notificationId": result.rows[0].notification_id,
+    "message": "Successfully created a notification"
+  }
+  return jsonResult;
 };
 
 export const notificationService = {

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -15,25 +15,14 @@ interface NotificationResponse{
 }
 
 const createNotification = async (notification: Notification): Promise<NotificationResponse> => {
-  try {
-    const result = await db.sql<InsertNotificationResult>('insert-notification', {
-      to_user_id: notification.toUserId,
-      notification_type: notification.notificationType,
-    });
-    return {
-      notificationId: result.rows[0].notification_id,
-      message: 'Successfully created a notification',
-    };
-  } catch (err: unknown) {
-    let errmessage = 'unknown error';
-    if (err instanceof Error) {
-      errmessage = err.message;
-    }
-    return {
-      notificationId: 0,
-      message: errmessage,
-    };
-  }
+  const result = await db.sql<InsertNotificationResult>('insert-notification', {
+    to_user_id: notification.toUserId,
+    notification_type: notification.notificationType,
+  });
+  return {
+    notificationId: result.rows[0].notification_id,
+    message: 'Successfully created a notification',
+  };
 };
 
 export const notificationService = {

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -14,9 +14,9 @@ const createNotification = async (notification: Notification): Promise<Object> =
     to_user_id: notification.toUserId,
     notification_type: notification.notificationType,
   });
-  var jsonResult = {
-    "notificationId": result.rows[0].notification_id,
-    "message": "Successfully created a notification"
+  const jsonResult = {
+    notificationId: result.rows[0].notification_id,
+    message: "Successfully created a notification"
   }
   return jsonResult;
 };

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -9,16 +9,31 @@ interface InsertNotificationResult{
   notification_id: number;
 }
 
-const createNotification = async (notification: Notification): Promise<unknown> => {
-  const result = await db.sql<InsertNotificationResult>('insert-notification', {
-    to_user_id: notification.toUserId,
-    notification_type: notification.notificationType,
-  });
-  const jsonResult = {
-    notificationId: result.rows[0].notification_id,
-    message: 'Successfully created a notification',
-  };
-  return jsonResult;
+interface NotificationResponse{
+  notificationId: number;
+  message: string;
+}
+
+const createNotification = async (notification: Notification): Promise<NotificationResponse> => {
+  try {
+    const result = await db.sql<InsertNotificationResult>('insert-notification', {
+      to_user_id: notification.toUserId,
+      notification_type: notification.notificationType,
+    });
+    return {
+      notificationId: result.rows[0].notification_id,
+      message: 'Successfully created a notification',
+    };
+  } catch (err: unknown) {
+    let errmessage = 'unknown error';
+    if (err instanceof Error) {
+      errmessage = err.message;
+    }
+    return {
+      notificationId: 0,
+      message: errmessage,
+    };
+  }
 };
 
 export const notificationService = {

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -9,15 +9,15 @@ interface InsertNotificationResult{
   notification_id: number;
 }
 
-const createNotification = async (notification: Notification): Promise<Object> => {
+const createNotification = async (notification: Notification): Promise<unknown> => {
   const result = await db.sql<InsertNotificationResult>('insert-notification', {
     to_user_id: notification.toUserId,
     notification_type: notification.notificationType,
   });
   const jsonResult = {
     notificationId: result.rows[0].notification_id,
-    message: "Successfully created a notification"
-  }
+    message: 'Successfully created a notification',
+  };
   return jsonResult;
 };
 


### PR DESCRIPTION
Earlier the notification service was returning a number. We would like
it to be a JSON instead.

To test make a POST to localhost:3001/api/notifications with input 
`{
    "toUserId": userId,
    "notificationType": "type.notification.create"
}`

The response should have the notification Id and a message. 