### PR TITLE
Send messages on notification creation

### DIFF
--- a/src/database/queries/delete-device-token.sql
+++ b/src/database/queries/delete-device-token.sql
@@ -1,0 +1,2 @@
+DELETE FROM devices
+WHERE device_token = :deviceToken

--- a/src/database/queries/get-device-tokens-for-user.sql
+++ b/src/database/queries/get-device-tokens-for-user.sql
@@ -1,0 +1,3 @@
+SELECT device_token
+FROM devices
+WHERE user_id = :userId

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -12,6 +12,20 @@ const addDevice = async (device: Device): Promise<void> => {
   });
 };
 
+const getDeviceTokensForUser = async (userId: number): Promise<string[]> => (
+  (await db.sql<{ device_token: string }>('get-device-tokens-for-user', {
+    userId,
+  })).rows.map((row) => row.device_token)
+);
+
+const removeDeviceToken = async (deviceToken: string): Promise<void> => {
+  await db.sql('delete-device-token', {
+    deviceToken,
+  });
+};
+
 export const deviceService = {
   addDevice,
+  getDeviceTokensForUser,
+  removeDeviceToken,
 };

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,4 +1,5 @@
 import { db } from '../database';
+import { sendMessageToUser } from './message.service';
 
 export interface Notification {
   toUserId: number;
@@ -18,6 +19,15 @@ const createNotification = async (notification: Notification): Promise<Notificat
   const result = await db.sql<InsertNotificationResult>('insert-notification', {
     to_user_id: notification.toUserId,
     notification_type: notification.notificationType,
+  });
+  setImmediate(() => {
+    sendMessageToUser(
+      notification.toUserId,
+      notification.notificationType,
+    ).catch((err: unknown) => (
+      // eslint-disable-next-line no-console -- TODO: set up Sentry
+      console.log('Error sending message to user', notification.toUserId, err)
+    ));
   });
   return {
     notificationId: result.rows[0].notification_id,


### PR DESCRIPTION
Send push notifications via Firebase Cloud Messaging to each device a user has registered when a new notification is created.

While the plan was originally to send [data messages](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages), after some testing with the mobile team, it seems such messages are not being received. However, they believe notification messages can be intercepted by the application before being displayed by the operating system, so that the system-facing strings can be replaced with user-facing strings.

Use the [`send` API](https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging-1#send), which appears to be the current supported API for sending FCM messages. We receive a unique message ID in response, but since as far as I can tell there is nothing we can do with that message ID, silently swallow it.

Use [`setImmediate`](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args) to queue up the calls to FCM, as we do not need to block the API request on talking to FCM. If some or all of the calls to FCM fail, then log an error to standard out; this behavior is not ideal, and we should set up Sentry to properly record and expose such errors. (See #9.)

There is one error we can handle: invalid or expired tokens. We do not (yet) validate the device token upon registration, but even if we did, tokens can expire. If FCM returns an invalid token error, remove it from the database, as it will never become valid again.

See also the other [errors FCM can return](https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode), which we are currently not handling beyond logging. Some probably do not need explicit handling, like "invalid TTL", as we're not setting that option; others, like the QUOTA_EXCEEDED category, are errors we should handle when we get to the scale of encountering such errors, and will require more complexity.

Issue #18 Send push notifications