### PR TITLE
Add logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,7 +2750,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4141,8 +4140,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "2.0.0",
@@ -4755,6 +4753,27 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
+    "express-winston": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/express-winston/-/express-winston-4.1.0.tgz",
+      "integrity": "sha512-0DaIjvNADBzC/K4Qw3UwEQc8HRjbajTaP/M43rw0LJpZcQ7SQTPfxkLsnx3ABHEO7EFNQXTpqL0BZPiwkGV8hg==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         }
       }
     },
@@ -5477,8 +5496,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -10154,7 +10172,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,6 +1193,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
@@ -2906,6 +2916,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -3524,11 +3539,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3536,13 +3559,30 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3699,8 +3739,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -4014,6 +4053,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4890,8 +4934,7 @@
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-text-encoding": {
       "version": "1.0.3",
@@ -4924,6 +4967,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fecha": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "file-entry-cache": {
       "version": "5.0.1",
@@ -5105,6 +5153,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -5948,8 +6001,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -7887,6 +7939,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7991,6 +8048,18 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
     },
     "long": {
       "version": "4.0.0",
@@ -8535,6 +8604,14 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -8882,9 +8959,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -9019,8 +9094,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9493,6 +9566,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -9775,6 +9863,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
       "version": "2.0.3",
@@ -10145,6 +10238,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10253,6 +10351,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-jest": {
       "version": "26.3.0",
@@ -10666,6 +10769,48 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-winston": "^4.1.0",
     "firebase-admin": "^9.6.0",
     "joi": "^17.2.1",
     "pg": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "pg": "^8.5.1",
     "postgres-migrations": "^5.1.1",
     "require-env-variable": "^3.1.2",
-    "tinypg": "^6.0.0"
+    "tinypg": "^6.0.0",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,11 @@
 import express from 'express';
+import expressWinston from 'express-winston';
 import bodyParser from 'body-parser';
 import { apiRoutes } from './routes';
+import { logger } from './log';
 
 const app = express();
+app.use(expressWinston.logger({ level: 'http', winstonInstance: logger }));
 app.use(bodyParser.json());
 app.use('/api', apiRoutes);
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { TinyPg } from 'tinypg';
 import { migrate as pgMigrate } from 'postgres-migrations';
+import { logger } from '../log';
 
 const db = new TinyPg({
   connection_string: process.env.DATABASE_URL,
@@ -12,8 +13,7 @@ const migrate = async (): Promise<void> => {
   await pgMigrate(
     { client },
     path.resolve(__dirname, 'migrations'),
-    // eslint-disable-next-line no-console -- TODO: set up proper logging
-    { logger: console.log },
+    { logger: logger.info },
   );
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 import './env';
 import { app } from './app';
 import { startup } from './startup';
+import { logger } from './log';
 
+const port = process.env.PORT ?? 3000;
 startup().then(() => (
-  app.listen(process.env.PORT ?? 3000)
+  app.listen(port, () => {
+    logger.info(`notification-service listening on port ${port}`);
+  })
 )).catch((err) => {
-  // eslint-disable-next-line no-console -- TODO: set up proper logging
-  console.error(err);
+  logger.error(err);
   process.exit(1);
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,49 @@
+import { createLogger, format, transports } from 'winston';
+import type { TransformableInfo } from 'logform';
+
+const {
+  colorize,
+  combine,
+  errors,
+  printf,
+  simple,
+} = format;
+
+const template = ({
+  level,
+  message,
+  stack,
+  ...rest
+}: TransformableInfo): string => {
+  const meta = Object.keys(rest).length > 0 ? ` ${JSON.stringify(rest)}` : '';
+  const stacktrace = typeof stack === 'string' ? `\n${stack}` : '';
+  const timestamp = new Date().toLocaleString();
+  return `${timestamp} ${level}: ${message}${meta}${stacktrace}`;
+};
+
+const debugLogger = createLogger({
+  format: combine(
+    errors({ stack: true }),
+    colorize(),
+    printf(template),
+  ),
+  level: process.env.LOG_LEVEL ?? 'debug',
+  transports: [
+    new transports.Console(),
+  ],
+});
+
+const prodLogger = createLogger({
+  format: combine(
+    errors({ stack: true }),
+    simple(),
+  ),
+  level: process.env.LOG_LEVEL ?? 'info',
+  transports: [
+    new transports.Console(),
+  ],
+});
+
+const logger = process.env.NODE_ENV === 'production' ? prodLogger : debugLogger;
+
+export { logger };

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -1,5 +1,6 @@
 import { db } from '../database';
 import { validateHealth } from './message.service';
+import { logger } from '../log';
 
 enum HealthStatus {
   AVAILABLE = 'available',
@@ -9,16 +10,14 @@ enum HealthStatus {
 const getHealth = async (): Promise<HealthStatus> => {
   try {
     await db.sql('health');
-  } catch (err: unknown) {
-    // eslint-disable-next-line no-console -- TODO: set up proper logging
-    console.log('Error connecting to database', err);
+  } catch (error: unknown) {
+    logger.error('Error connecting to database', { error });
     return HealthStatus.UNAVAILABLE;
   }
   try {
     await validateHealth();
-  } catch (err: unknown) {
-    // eslint-disable-next-line no-console -- TODO: set up proper logging
-    console.log('Error connecting to Firebase', err);
+  } catch (error: unknown) {
+    logger.error('Error connecting to Firebase', { error });
     return HealthStatus.UNAVAILABLE;
   }
   return HealthStatus.AVAILABLE;

--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import type { messaging, ServiceAccount } from 'firebase-admin';
 import { deviceService } from './device.service';
+import { logger } from '../log';
 
 const credentials: unknown = JSON.parse(
   process.env.FIREBASE_CREDENTIALS as string,
@@ -48,8 +49,7 @@ const sendMessageToDevice = async (
     });
   } catch (err: unknown) {
     if (isInvalidTokenError(err)) {
-      // eslint-disable-next-line no-console -- TODO: set up proper logging
-      console.log('Removing expired or invalid token', deviceToken);
+      logger.warn(`Removing expired or invalid token: ${deviceToken}`);
       await deviceService.removeDeviceToken(deviceToken);
       return '';
     }

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,5 +1,6 @@
 import { db } from '../database';
 import { sendMessageToUser } from './message.service';
+import { logger } from '../log';
 
 export interface Notification {
   toUserId: number;
@@ -24,9 +25,9 @@ const createNotification = async (notification: Notification): Promise<Notificat
     sendMessageToUser(
       notification.toUserId,
       notification.notificationType,
-    ).catch((err: unknown) => (
-      // eslint-disable-next-line no-console -- TODO: set up Sentry
-      console.log('Error sending message to user', notification.toUserId, err)
+    ).catch((error: unknown) => (
+      // TODO: set up Sentry
+      logger.error(`Error sending message to user ${notification.toUserId}`, { error })
     ));
   });
   return {


### PR DESCRIPTION
Set up Winston ([npm](https://www.npmjs.com/package/winston), [repo](https://github.com/winstonjs/winston
)), "a logger for just about everything."

Winston offers a lot of customization of both the format and the destination of log messages. Currently, we're saving our logs to syslog via systemd capturing stdout, so for simplicity's sake, we will continue to do that, at least for now.

However, logging in production is very different from logging in development. In production, systemd automatically timestamps log lines, but when running the service via `npm start`, we do not get timestamps by default. Additionally, while we don't need or want colors in our production logs, they're helpful in development. Finally, making logs easy-to-read is important in dev, but in production it's more important to make logs easy to separate.

So: in development, show timestamps in the user's locale & time zone, with color, and spanning multiple lines if necessary; in production, rely on systemd to provide timestamps, do not colorize logs, and make sure each log statement produces only a single line.

Convert our various TODOs about logging to the console to instead use Winston. We do also still want to set up Sentry, particularly around the errors, but this is still a useful step. Also, for the sake of debugging in both dev and prod, log when the service has successfully started up, as well as Express requests via the express-winston library ([npm](https://www.npmjs.com/package/express-winston), [repo](https://github.com/bithavoc/express-winston)). This captures log lines approximately like so:

```
info: notification-service listening on port 3001
http: HTTP POST /api/devices {"meta":{"req":{"url":"/api/devices","headers":{"host":"localhost:3001","user-agent":"curl/7.58.0","accept":"*/*","content-type":"application/json","content-length":"33"},"method":"POST","httpVersion":"1.1","originalUrl":"/api/devices","query":{}},"res":{"statusCode":200},"responseTime":27}}
http: HTTP POST /api/notifications {"meta":{"req":{"url":"/api/notifications","headers":{"host":"localhost:3001","user-agent":"curl/7.58.0","accept":"*/*","content-type":"application/json","content-length":"40"},"method":"POST","httpVersion":"1.1","originalUrl":"/api/notifications","query":{}},"res":{"statusCode":200},"responseTime":12}}
warn: Removing expired or invalid token: test
http: HTTP GET /api/health {"meta":{"req":{"url":"/api/health","headers":{"host":"localhost:3001","user-agent":"curl/7.58.0","accept":"*/*"},"method":"GET","httpVersion":"1.1","originalUrl":"/api/health","query":{}},"res":{"statusCode":200},"responseTime":397}}
```

I set the log level for Express requests to `http` so that this will log requests in development, but not in production. If we decide we need more detail, we can (manually or permanently) add an environment variable `LOG_LEVEL` to our application configuration.

This should not be deployed until after https://github.com/PermanentOrg/infrastructure/pull/55 , so as to avoid cluttering up our production logs with the debug log level we'd get before that change.

To test this, simply check out the branch and start the application. To see the logs it will emit in production (albeit without the wrapping systemd provides), run `NODE_ENV=production npm start`.