### PR TITLE
Add mutable content header

### DIFF
--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -46,6 +46,13 @@ const sendMessageToDevice = async (
       notification: {
         body: notificationType,
       },
+      apns: {
+        payload: {
+          aps: {
+            'mutable-content': true,
+          },
+        },
+      },
       data: {
         notificationType,
         ...context,


### PR DESCRIPTION
I am not sure if this is formatted correctly or in the right spot,
could definitely use some guidance!  Specifically I'm not sure if I
need the quotes or not, since we are not using them elsewhere (e.g. on
"notification" and "body").

@v-rusu wrote:
In the notification message, we are missing a field that allows us to
read the notification context before presenting it to the user in iOS
- this means we’re not able to compose the notification title and body
at the moment.  I’m sorry I forgot to mention about this, firebase
console adds it automatically so it slipped my mind. What we’re looking
for is the “mutable-content” header field, and it should look like
this:

“apns”: { “payload”: { “aps”: { “mutable-content”: 1 } } }

More info on it here: https://firebase.google.com/docs/cloud-messaging/ios/send-image
