### PR TITLE
Send data messages to Android, and alerts to iOS

### DIFF
--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -43,12 +43,12 @@ const sendMessageToDevice = async (
   try {
     const messageId = await sendMessage({
       token: deviceToken,
-      notification: {
-        body: notificationType,
-      },
       apns: {
         payload: {
           aps: {
+            alert: {
+              body: notificationType,
+            },
             'mutable-content': true,
           },
         },


### PR DESCRIPTION
The iOS app needs to receive Firebase messages as push notifications to ensure timely delivery and so that the OS will call into the app. The Android app, on the other hand, should receive Firebase messages as data messages, to prevent the OS from automatically generating a user-facing notification.

While the original plan was to send data messages only, we discovered the issue with iOS, and in PR #30 defaulted to always sending push notifications.

Fortunately, Firebase offers a way to have platform-specific behavior without needing to know which platform a given device is on, by adding options to the platform's configuration - in this case, `apns` (Apple Push Notification Service).

See: https://firebase.google.com/docs/cloud-messaging/concept-options

Thanks to @flaviahandrea-vsp and @v-rusu for articulating the problem and figuring out a solution!