### PR TITLE
Make device_token unique

### DIFF
--- a/src/database/migrations/5-alter-device-table.sql
+++ b/src/database/migrations/5-alter-device-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE devices
+ADD CONSTRAINT unique_device_token UNIQUE (device_token);

--- a/src/database/queries/insert-devices.sql
+++ b/src/database/queries/insert-devices.sql
@@ -1,4 +1,4 @@
 INSERT
 INTO devices (user_id, device_token)
 VALUES (:user_id, :device_token)
-ON CONFLICT DO NOTHING
+ON CONFLICT ON CONSTRAINT unique_device_token DO UPDATE SET user_id = :user_id;


### PR DESCRIPTION
This is a fix for the case when:
 - userA logs in on deviceA
 - userB logs in on the same deviceA
 - userA receives a push notification, but userB sees it because they are logged in on deviceA

A manual clean of the duplicates in the devices table is required before deploying this, otherwise the migration scripts will fail.