### PR TITLE
Explicitly depend on ESLint configurations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,9 +3,13 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint",
+    "import"
+  ],
   "extends": [
     "plugin:@typescript-eslint/all",
+    "airbnb-base",
     "airbnb-typescript/base"
   ],
   "rules": {


### PR DESCRIPTION
This repo is my go-to reference repo for TypeScript at Permanent. Unfortunately, when I tried to clone our ESLint configuration elsewhere, I ran into some surprising bugs!

The configuration for ESLint we want is a combination of multiple well-known configurations. Currently, the old version of eslint-config-airbnb-typescript we're depending on appears to implicitly depend on eslint-config-airbnb-base and eslint-plugin-import, but a later version does not, which means upgrading would have caused our configuration to inadvertently most of its rules.

Explicitly extend the airbnb-base ruleset, and explicitly depend on the import plugin, so that later upgrades are safe and simple.

Upgrading ESLint and the upstream rulesets we're using will require more changes, as there are new requirements that this codebase does not meet, so given our limited dev capacity I'll leave that for later. We should also look at upgrading the versions of Node.js and TypeScript we're using.