### PR TITLE
Update @node/types to v22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@tsconfig/node22": "^22.0.2",
 				"@types/express": "^5.0.3",
 				"@types/jest": "^26.0.23",
-				"@types/node": "^14.18.3",
+				"@types/node": "^22.16.2",
 				"@types/pg": "^8.15.1",
 				"@types/supertest": "^2.0.10",
 				"eslint": "^9.30.1",
@@ -1989,9 +1989,19 @@
 			"integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
 		},
 		"node_modules/@types/node": {
-			"version": "14.18.42",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-			"integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg=="
+			"version": "22.16.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.2.tgz",
+			"integrity": "sha512-Cdqa/eJTvt4fC4wmq1Mcc0CPUjp/Qy2FGqLza3z3pKymsI969TcZ54diNJv8UYUgeWxyb8FSbCkhdR6WqmUFhA==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/node/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
 		},
 		"node_modules/@types/pg": {
 			"version": "8.15.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@tsconfig/node22": "^22.0.2",
 		"@types/express": "^5.0.3",
 		"@types/jest": "^26.0.23",
-		"@types/node": "^14.18.3",
+		"@types/node": "^22.16.2",
 		"@types/pg": "^8.15.1",
 		"@types/supertest": "^2.0.10",
 		"eslint": "^9.30.1",


### PR DESCRIPTION
This PR bumps our node types to align with the target node version.

It also updates dependabot's instructions so that we won't be pressured to bump types for Node 24 before we're actually using Node 24

Related to #122