### PR TITLE
Remove `dotenv`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@pdc/http-status-codes": "^1.0.1",
-				"dotenv": "^17.2.2",
 				"express": "^5.1.0",
 				"express-winston": "^4.2.0",
 				"firebase-admin": "^13.5.0",
@@ -4215,18 +4214,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "17.2.2",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-			"integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	},
 	"dependencies": {
 		"@pdc/http-status-codes": "^1.0.1",
-		"dotenv": "^17.2.2",
 		"express": "^5.1.0",
 		"express-winston": "^4.2.0",
 		"firebase-admin": "^13.5.0",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,3 @@
-import { config } from "dotenv";
 import { requireEnv } from "require-env-variable";
-
-config();
 
 requireEnv("DATABASE_URL", "FIREBASE_CREDENTIALS");


### PR DESCRIPTION
This PR removes our use of `dotenv`

This is in line with how we orchestrate our various environments via IaC.

Before merging this we should confirm that our `infrastructure` is, in fact, populating environment state without use of code-level `.env` files.  If that is not the case then we should change that approach to enable the merging of this PR.

Resolves #186